### PR TITLE
In 471 test directory parser v1.4.0

### DIFF
--- a/configs/240226_RD.json
+++ b/configs/240226_RD.json
@@ -1,14 +1,14 @@
 {
     "name": "240226_RD",
-    "sheet_of_interest": "R&ID indications",
+    "sheet_of_interest": "Sheet1",
     "clinical_indication_column_code": "Test ID",
     "clinical_indication_column_name": "Clinical Indication",
     "panel_column": "Target/Genes",
     "test_method_column": "Test Method",
     "changes_column": "Changes",
-    "specialty_column": "Specialist test group",
-    "header_index": 1,
-    "specialism_of_interest": ["Core", "Endocrinology", "Neurology"],
+    "ngs_column": "NGS Technology",
+    "header_index": 0,
+    "ngs_type": ["WES", "CEN"],
     "ngs_test_methods": [
         "Medium panel", "Single gene sequencing <=10 amplicons",
         "Single gene sequencing <10 amplicons",

--- a/test_directory_parser/rare_disease.py
+++ b/test_directory_parser/rare_disease.py
@@ -31,44 +31,44 @@ def parse_rare_disease_td(test_directory: str, config: dict):
     """
 
     xls = pd.read_excel(
-        test_directory, sheet_name=None, header=config["header_index"]
+        test_directory,
+        sheet_name=config["sheet_of_interest"],
+        header=config["header_index"]
     )
 
-    for sheet in xls:
-        if sheet == config["sheet_of_interest"]:
-            # find name of change column
-            change_column = [
-                col for col in xls[sheet].columns
-                if config['changes_column'].lower() in col.lower()
-            ]
+    # find name of change column
+    change_column = [
+        col for col in xls.columns
+        if config['changes_column'].lower() in col.lower()
+    ]
 
-            if change_column:
-                if len(change_column) == 1:
-                    change_column = change_column[0]
-                else:
-                    raise Exception((
-                        "2 or more columns were detected as having "
-                        f"'{config['changes_column']}' "
-                        "in their name breaking the changes gathering.\n"
-                        f"Matched column names: {';'.join(change_column)}"
-                    ))
-            else:
-                raise Exception("Couldn't find the change column.")
+    if change_column:
+        if len(change_column) == 1:
+            change_column = change_column[0]
+        else:
+            raise Exception((
+                "2 or more columns were detected as having "
+                f"'{config['changes_column']}' "
+                "in their name breaking the changes gathering.\n"
+                f"Matched column names: {';'.join(change_column)}"
+            ))
+    else:
+        raise Exception("Couldn't find the change column.")
 
-            data = xls[sheet].loc(axis=1)[
-                config["clinical_indication_column_code"],
-                config["clinical_indication_column_name"],
-                config["panel_column"],
-                config["test_method_column"],
-                config["specialty_column"],
-                change_column
-            ]
+    data = xls.loc(axis=1)[
+        config["clinical_indication_column_code"],
+        config["clinical_indication_column_name"],
+        config["panel_column"],
+        config["test_method_column"],
+        config["ngs_column"],
+        change_column
+    ]
 
-    # filter using the specialisms used in the lab
+    # # filter using the NGS tests used in the lab
     filtered_data = data.loc[
         data[
-            config["specialty_column"]
-        ].isin(config["specialism_of_interest"])
+            config["ngs_column"]
+        ].isin(config["ngs_type"])
     ]
 
     return filtered_data, change_column

--- a/test_directory_parser/rare_disease.py
+++ b/test_directory_parser/rare_disease.py
@@ -64,7 +64,7 @@ def parse_rare_disease_td(test_directory: str, config: dict):
         change_column
     ]
 
-    # # filter using the NGS tests used in the lab
+    # filter using the NGS tests used in the lab
     filtered_data = data.loc[
         data[
             config["ngs_column"]

--- a/test_directory_parser/tests/test_rare_disease.py
+++ b/test_directory_parser/tests/test_rare_disease.py
@@ -15,16 +15,16 @@ class TestRareDisease(unittest.TestCase):
 
     def setUp(self) -> None:
         self.test_config = {
-            "name": "Test_config",
-            "sheet_of_interest": "R&ID indications",
+            "name": "Test config",
+            "sheet_of_interest": "Sheet1",
             "clinical_indication_column_code": "Test ID",
             "clinical_indication_column_name": "Clinical Indication",
             "panel_column": "Target/Genes",
             "test_method_column": "Test Method",
             "changes_column": "Changes",
-            "specialty_column": "Specialist test group",
-            "header_index": 1,
-            "specialism_of_interest": ["Core", "Endocrinology", "Neurology"],
+            "ngs_column": "NGS Technology",
+            "header_index": 0,
+            "ngs_type": ["WES", "CEN"],
             "ngs_test_methods": [
                 "Medium panel", "Single gene sequencing <=10 amplicons",
                 "Single gene sequencing <10 amplicons",
@@ -56,20 +56,18 @@ class TestRareDisease(unittest.TestCase):
         - Correct parsing of td_excel data
         """
 
-        mock_td_excel.return_value = {
-            "R&ID indications": pd.DataFrame(
-                {
-                    "Clinical indication ID": ["R100", "R300"],
-                    "Test ID": ["R100.1", "R300.1"],
-                    "Clinical Indication": ["CI1", "CI2"],
-                    "Target/Genes": ["Panel1", "Panel2"],
-                    "Test Method": ["WES", "WES"],
-                    "Commissioning category": ["Category1", "Category2"],
-                    "Specialist test group": ["Core", "Oncology"],
-                    "Changes since April 2023 publication": ["No change", "No change"]
-                }
-            )
-        }
+        mock_td_excel.return_value = pd.DataFrame(
+            {
+                "Clinical indication ID": ["R100", "R300"],
+                "Test ID": ["R100.1", "R300.1"],
+                "Clinical Indication": ["CI1", "CI2"],
+                "Target/Genes": ["Panel1", "Panel2"],
+                "Test Method": ["WES", "WES"],
+                "Commissioning category": ["Category1", "Category2"],
+                "NGS Technology": ["WES", "Not WES"],
+                "Changes since April 2023 publication": ["No change", "No change"]
+            }
+        )
 
         expected_output = pd.DataFrame(
             {
@@ -77,7 +75,7 @@ class TestRareDisease(unittest.TestCase):
                 "Clinical Indication": ["CI1"],
                 "Target/Genes": ["Panel1"],
                 "Test Method": ["WES"],
-                "Specialist test group": ["Core"],
+                "NGS Technology": ["WES"],
                 "Changes since April 2023 publication": ["No change"]
             }
         )
@@ -107,21 +105,19 @@ class TestRareDisease(unittest.TestCase):
         - Exception raised because 2 >= columns with changes in their header 
         """
 
-        mock_td_excel.return_value = {
-            "R&ID indications": pd.DataFrame(
-                {
-                    "Clinical indication ID": ["R100"],
-                    "Test ID": ["R100.1"],
-                    "Clinical Indication": ["CI1"],
-                    "Target/Genes": ["Panel1"],
-                    "Test Method": ["WES"],
-                    "Commissioning category": ["Category1"],
-                    "Specialist test group": ["Core"],
-                    "Changes since April 2023 publication": ["No change"],
-                    "Other changes": ["Kinda change"]
-                }
-            )
-        }
+        mock_td_excel.return_value = pd.DataFrame(
+            {
+                "Clinical indication ID": ["R100"],
+                "Test ID": ["R100.1"],
+                "Clinical Indication": ["CI1"],
+                "Target/Genes": ["Panel1"],
+                "Test Method": ["WES"],
+                "Commissioning category": ["Category1"],
+                "Specialist test group": ["Core"],
+                "Changes since April 2023 publication": ["No change"],
+                "Other changes": ["Kinda change"]
+            }
+        )
 
         with self.assertRaises(Exception):
             test_output, test_change_column = parse_rare_disease_td(
@@ -141,19 +137,17 @@ class TestRareDisease(unittest.TestCase):
         - Exception raised because 0 columns with "changes" in their header 
         """
 
-        mock_td_excel.return_value = {
-            "R&ID indications": pd.DataFrame(
-                {
-                    "Clinical indication ID": ["R100"],
-                    "Test ID": ["R100.1"],
-                    "Clinical Indication": ["CI1"],
-                    "Target/Genes": ["Panel1"],
-                    "Test Method": ["WES"],
-                    "Commissioning category": ["Category1"],
-                    "Specialist test group": ["Core"],
-                }
-            )
-        }
+        mock_td_excel.return_value = pd.DataFrame(
+            {
+                "Clinical indication ID": ["R100"],
+                "Test ID": ["R100.1"],
+                "Clinical Indication": ["CI1"],
+                "Target/Genes": ["Panel1"],
+                "Test Method": ["WES"],
+                "Commissioning category": ["Category1"],
+                "Specialist test group": ["Core"],
+            }
+        )
 
         with self.assertRaises(Exception):
             test_output, test_change_column = parse_rare_disease_td(


### PR DESCRIPTION
- Config to use the internal TD
    - Use the `NGS Technology` column to filter down the number of clinical indications that we handle
    - Change the code to use the `NGS technology` column
- Adjust the tests to match the new inputs and whatnot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/test_directory_parser/25)
<!-- Reviewable:end -->
